### PR TITLE
Web の wasm 解決エラーを回避する

### DIFF
--- a/calmvibe/README.md
+++ b/calmvibe/README.md
@@ -14,6 +14,7 @@ npm install
 - Web: `npm run web`
 - Lint: `npm run lint`
 - テスト: `npm test -- --runInBand`
+- Webビルド確認: `npx expo export -p web`
 ※ スタンドアロンAPKの導入手順は、ルートの `README.md` を参照してください。
 
 ## 技術スタック

--- a/calmvibe/app/__tests__/apk-launch.test.tsx
+++ b/calmvibe/app/__tests__/apk-launch.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { View } from 'react-native';
 import { render } from '@testing-library/react-native';
 import RootLayout from '../_layout';
 

--- a/calmvibe/src/bootstrap/databaseCompatibility.web.ts
+++ b/calmvibe/src/bootstrap/databaseCompatibility.web.ts
@@ -1,0 +1,15 @@
+export const dbSchemaVersion = 1;
+
+let checked = false;
+
+export const resetDatabaseCompatibilityCache = () => {
+  checked = false;
+};
+
+/**
+ * WebではSQLite互換性チェックを行わない。
+ */
+export const ensureDatabaseCompatibility = async (): Promise<void> => {
+  if (checked) return;
+  checked = true;
+};

--- a/calmvibe/src/settings/sqliteRepository.web.ts
+++ b/calmvibe/src/settings/sqliteRepository.web.ts
@@ -1,7 +1,8 @@
 import { SettingsRepository, SettingsValues, defaultSettings } from './types';
 
-const memoryStore: { value: SettingsValues | null } = { value: null };
-
+/**
+ * Web用のメモリ実装。expo-sqlite を参照しない。
+ */
 export class SqliteSettingsRepository implements SettingsRepository {
   async get(): Promise<SettingsValues> {
     if (!memoryStore.value) memoryStore.value = defaultSettings;
@@ -9,6 +10,30 @@ export class SqliteSettingsRepository implements SettingsRepository {
   }
 
   async save(values: SettingsValues): Promise<void> {
-    memoryStore.value = values;
+    memoryStore.value = normalize(values);
   }
 }
+
+const memoryStore: { value: SettingsValues | null } = { value: null };
+
+const normalize = (values: SettingsValues): SettingsValues => ({
+  bpm: clamp(values.bpm, 40, 120, defaultSettings.bpm),
+  durationSec: values.durationSec === null ? null : clamp(values.durationSec, 60, 300, defaultSettings.durationSec as number),
+  intensity: values.intensity,
+  breath: normalizeBreath(values.breath),
+});
+
+const clamp = (val: number, min: number, max: number, fallback: number) => {
+  if (typeof val !== 'number' || Number.isNaN(val)) return fallback;
+  if (val < min || val > max) return fallback;
+  return val;
+};
+
+const normalizeBreath = (breath: SettingsValues['breath']) => {
+  if (breath.type === 'two-phase') {
+    if (breath.inhaleSec <= 0 || breath.exhaleSec <= 0) return defaultSettings.breath;
+    return breath;
+  }
+  if (breath.inhaleSec <= 0 || breath.exhaleSec <= 0 || breath.holdSec <= 0) return defaultSettings.breath;
+  return breath;
+};


### PR DESCRIPTION

## 概要
Web ビルド時に `expo-sqlite` の wasm 解決エラーが発生するため、Web では `expo-sqlite` を参照しない実装に切り替えた。あわせて開発ガイドに Web ビルド確認手順を追記した。

## 変更点
- Web 向けの設定リポジトリをメモリ実装に切り替え
- Web 向けのDB互換性チェックをスキップする実装を追加
- Web ビルド確認コマンドを README に追記
- テストの未使用 import を整理

## 関連Issue
- #15

## 動作確認
- `npm run lint`
- `npm test -- --runInBand`
- `npx expo export -p web`
