### PR TITLE
CI に Web ビルド検証を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Test
         run: npm test -- --runInBand
         working-directory: calmvibe
+      - name: Web Build
+        run: npx expo export -p web
+        working-directory: calmvibe
       - name: Build
         run: npm run build --if-present
         working-directory: calmvibe


### PR DESCRIPTION
## 概要
CI に Web のビルド検証を追加し、Web 特有の依存解決エラーを早期に検知できるようにした。

## 変更点
- GitHub Actions の CI に `npx expo export -p web` を追加

## 関連Issue
- #17

## 動作確認
- 該当なし（CIで実行）
