### PR TITLE
fix: Safe Area対応

### DIFF
--- a/.kiro/specs/calm-heart-rate-app/design.md
+++ b/.kiro/specs/calm-heart-rate-app/design.md
@@ -193,6 +193,7 @@ sequenceDiagram
 - **Contracts**: State ☑
 - **Implementation Notes**
   - `app/(tabs)/_layout.tsx` で `Tabs.Screen` を `name="session"` と `name="logs"` の2つだけに設定し、`initialRouteName="session"` を明示。`detachInactiveScreens={false}` `lazy={false}` を指定してタブ切替時のアンマウントを避ける。
+  - `app/_layout.tsx` の最上位で `SafeAreaProvider` を適用し、各画面が safe area inset を参照できるようにする。
   - 既存の `index.tsx` / `explore.tsx` は削除し、新規に `app/(tabs)/session.tsx` で `SessionScreen` を、`app/(tabs)/logs.tsx` で `LogsScreen` をラップする薄いコンポーネントを配置する。
   - タブアイコン・ラベル: Session=「セッション」(heartbeat系アイコン)、Logs=「履歴」(list系アイコン)。アクセシビリティラベルを各タブに付与。
 
@@ -304,7 +305,9 @@ interface SessionRepository {
 - **Notes**: recordedAt DESC + id DESCインデックスで安定ソート。cursorは(recordedAt,id)で保持。breathConfigはJSON文字列で永続化。削除はトランザクションでまとめて実行し、存在しないIDは無視する。
 
 ### Tab/Logs UI Components (State)
+- **SessionScreen**: 上部がステータスバーに重ならないよう、`SafeAreaView`（`edges={['top']}`）または `useSafeAreaInsets` で `paddingTop` を付与する。タブ下部の safe area はタブバー側に委譲する。
 - **LogsScreen**: 初回は「表示されたタイミング（初回フォーカス時）」に `SessionRepository.listPage` から最新分を取得し、recordedAt 降順で表示（UI側で追加ソートはしない）。タブ再表示時は自動で再取得せず、表示内容を維持する。`onEndReached` で追加ページを取得し、既存リストに追記する。Pull-to-Refresh を実装し、更新時は最新1ページ分を再取得して既存一覧に重複なく先頭追加する（ページングのcursorは維持）。空表示時でも Pull-to-Refresh を実行できるようにする。タップで詳細へ（既存ログUIを流用/拡張）。
+  - Safe Area: セッション同様、上部は `SafeAreaView`/`useSafeAreaInsets` で余白を確保し、ステータスバーに重ならないようにする。
   - 選択モード: 「選択」操作で複数選択に対応する。カード左に常設の余白を設け、選択時は左中央にチェックバッジ（✓）を表示し、背景色で強調する。選択件数の表示は不要。
   - 削除導線: 削除前に確認ダイアログで件数を提示し、確認後に `SessionRepository.deleteMany` を実行して一覧から即時除外する。
   - キャンセル: 選択解除またはキャンセルで通常表示に戻る。

--- a/calmvibe/app/_layout.tsx
+++ b/calmvibe/app/_layout.tsx
@@ -4,6 +4,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { StyleSheet } from 'react-native';
 import { useKeepAwake } from 'expo-keep-awake';
 import { Ionicons } from '@expo/vector-icons';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { useDatabaseCompatibility } from '../src/bootstrap/useDatabaseCompatibility';
 
 export default function RootLayout() {
@@ -14,38 +15,40 @@ export default function RootLayout() {
   }
   return (
     <GestureHandlerRootView style={styles.container}>
-      <Tabs
-        initialRouteName="session"
-        detachInactiveScreens={false}
-        lazy={false}
-        screenOptions={{
-          headerShown: false,
-        }}>
-        <Tabs.Screen
-          name="index"
-          options={{
-            href: null, // ルートは /session へリダイレクトするだけでタブには出さない
-          }}
-        />
-        <Tabs.Screen
-          name="session"
-          options={{
-            title: 'セッション',
-            tabBarIcon: ({ color, size }) => (
-              <Ionicons name="pulse-outline" size={size} color={color} />
-            ),
-          }}
-        />
-        <Tabs.Screen
-          name="logs"
-          options={{
-            title: '履歴',
-            tabBarIcon: ({ color, size }) => (
-              <Ionicons name="time-outline" size={size} color={color} />
-            ),
-          }}
-        />
-      </Tabs>
+      <SafeAreaProvider>
+        <Tabs
+          initialRouteName="session"
+          detachInactiveScreens={false}
+          lazy={false}
+          screenOptions={{
+            headerShown: false,
+          }}>
+          <Tabs.Screen
+            name="index"
+            options={{
+              href: null, // ルートは /session へリダイレクトするだけでタブには出さない
+            }}
+          />
+          <Tabs.Screen
+            name="session"
+            options={{
+              title: 'セッション',
+              tabBarIcon: ({ color, size }) => (
+                <Ionicons name="pulse-outline" size={size} color={color} />
+              ),
+            }}
+          />
+          <Tabs.Screen
+            name="logs"
+            options={{
+              title: '履歴',
+              tabBarIcon: ({ color, size }) => (
+                <Ionicons name="time-outline" size={size} color={color} />
+              ),
+            }}
+          />
+        </Tabs>
+      </SafeAreaProvider>
     </GestureHandlerRootView>
   );
 }

--- a/calmvibe/app/logs.tsx
+++ b/calmvibe/app/logs.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Alert, FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useIsFocused } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { RecordDraft, SessionListCursor, SessionRecord, SessionRecordUpdate, SessionRepository } from '../src/session/types';
 import { SqliteSessionRepository } from '../src/session/sqliteRepository';
 import RecordModal from '../components/record-modal';
@@ -10,12 +11,16 @@ type Props = {
 };
 
 const PAGE_SIZE = 20;
+const basePadding = 24;
 
 export default function LogsScreen({ repo: injectedRepo }: Props) {
   const repo = useMemo<SessionRepository>(() => injectedRepo ?? new SqliteSessionRepository(), [injectedRepo]);
   const mountedRef = useRef(true);
   const hasFetchedRef = useRef(false);
   const isFocused = useIsFocused();
+  // SafeAreaViewだとFlatListの余白が崩れやすいため、上部だけ手動で足す
+  const insets = useSafeAreaInsets();
+  const containerStyle = [styles.container, { paddingTop: basePadding + insets.top }];
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
@@ -163,7 +168,7 @@ export default function LogsScreen({ repo: injectedRepo }: Props) {
 
   if (loading) {
     return (
-      <View style={[styles.container, styles.center]}>
+      <View style={[...containerStyle, styles.center]}>
         <ActivityIndicator />
         <Text style={styles.body}>読み込み中...</Text>
       </View>
@@ -172,7 +177,7 @@ export default function LogsScreen({ repo: injectedRepo }: Props) {
 
   if (data.length === 0) {
     return (
-      <View style={[styles.container, styles.center]}>
+      <View style={[...containerStyle, styles.center]}>
         <View style={styles.headerRow}>
           <Text style={styles.title}>履歴</Text>
           <View style={styles.headerActions}>
@@ -204,7 +209,7 @@ export default function LogsScreen({ repo: injectedRepo }: Props) {
   }
 
   return (
-    <View style={styles.container}>
+    <View style={containerStyle}>
       <View style={styles.headerRow}>
         <Text style={styles.title}>履歴</Text>
         <View style={styles.headerActions}>
@@ -418,7 +423,7 @@ const retryOnce = async (fn: () => Promise<void>) => {
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 24 },
+  container: { flex: 1, padding: basePadding },
   center: { justifyContent: 'center', alignItems: 'center' },
   headerRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12, width: '100%' },
   headerActions: { flexDirection: 'row', alignItems: 'center', gap: 8 },

--- a/calmvibe/app/session.tsx
+++ b/calmvibe/app/session.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { View, Text, Pressable, StyleSheet, ScrollView, ActivityIndicator, Alert } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { VisualGuide } from '../components/visual-guide';
 import { SettingsRepository, BreathPattern } from '../src/settings/types';
 import { SessionUseCase } from '../src/session/useCase';
@@ -17,6 +18,8 @@ const breathPresets: { label: string; pattern: BreathPattern }[] = [
   { label: '4-6-4 (5回)', pattern: { type: 'three-phase', inhaleSec: 4, holdSec: 6, exhaleSec: 4, cycles: 5 } },
 ];
 
+const basePadding = 20;
+
 export default function SessionScreen({ settingsRepo, useCase: injectedUseCase, viewModel: injectedViewModel }: SessionScreenProps) {
   const viewModel = useMemo(() => {
     if (injectedViewModel) return injectedViewModel;
@@ -27,6 +30,9 @@ export default function SessionScreen({ settingsRepo, useCase: injectedUseCase, 
   }, [injectedViewModel, injectedUseCase, settingsRepo]);
   const state = useSessionViewModel(viewModel);
   const repeatTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // SafeAreaViewだとScrollViewの余白が崩れやすいため、上部だけ手動で足す
+  const insets = useSafeAreaInsets();
+  const containerStyle = [styles.container, { paddingTop: basePadding + insets.top }];
 
   const stopRepeat = () => {
     if (repeatTimer.current) {
@@ -50,7 +56,7 @@ export default function SessionScreen({ settingsRepo, useCase: injectedUseCase, 
 
   if (state.loading) {
     return (
-      <View style={[styles.container, styles.center]}>
+      <View style={[...containerStyle, styles.center]}>
         <ActivityIndicator />
         <Text style={styles.body}>読み込み中...</Text>
       </View>
@@ -60,7 +66,7 @@ export default function SessionScreen({ settingsRepo, useCase: injectedUseCase, 
   if (!state.values) return null;
 
   return (
-    <ScrollView contentContainerStyle={styles.container}>
+    <ScrollView contentContainerStyle={containerStyle}>
       <Text style={styles.title}>セッション開始</Text>
       <View style={styles.modeRow}>
         <Pressable
@@ -318,7 +324,7 @@ const useSessionViewModel = (viewModel: SessionViewModel) => {
 };
 
 const styles = StyleSheet.create({
-  container: { padding: 20, gap: 12 },
+  container: { padding: basePadding, gap: 12 },
   center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   title: { fontSize: 18, fontWeight: '700', marginBottom: 8 },
   card: { backgroundColor: '#f4f6fb', borderRadius: 12, padding: 12, gap: 10 },

--- a/calmvibe/jest.setup.js
+++ b/calmvibe/jest.setup.js
@@ -8,6 +8,16 @@ configure({
   concurrentRoot: false,
 });
 
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    SafeAreaProvider: ({ children }) => React.createElement(View, null, children),
+    SafeAreaView: ({ children, ...props }) => React.createElement(View, props, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
 // Jest環境でExpoのimport meta registryがない問題への暫定対応
 if (!globalThis.__ExpoImportMetaRegistry) {
   globalThis.__ExpoImportMetaRegistry = {};


### PR DESCRIPTION
## 概要
セッション/履歴画面がステータスバーと重なる問題を、safe area の上部余白を手動で付与する形で解消しました。

## 変更点
- `SafeAreaProvider` をルートレイアウトに追加
- `session`/`logs` 画面で `useSafeAreaInsets` を使い上部余白を加算
- Jest で safe-area-context をモックしてテスト安定化

## 関連Issue
- #19

## 動作確認
- `npm test`
- `npm run lint`
- スクリーンショット: 未添付（必要なら撮影します）
