### PR TITLE
fix: 空履歴でも pull-to-refresh が動くようにする

### DIFF
--- a/calmvibe/app/logs.tsx
+++ b/calmvibe/app/logs.tsx
@@ -175,39 +175,6 @@ export default function LogsScreen({ repo: injectedRepo }: Props) {
     );
   }
 
-  if (data.length === 0) {
-    return (
-      <View style={[...containerStyle, styles.center]}>
-        <View style={styles.headerRow}>
-          <Text style={styles.title}>履歴</Text>
-          <View style={styles.headerActions}>
-            <Pressable accessibilityLabel="logs-select-toggle" onPress={selectionMode ? exitSelectionMode : enterSelectionMode}>
-              <Text style={styles.selectToggleLabel}>{selectionMode ? 'キャンセル' : '選択'}</Text>
-            </Pressable>
-            {selectionMode && (
-              <Pressable
-                accessibilityLabel="logs-delete"
-                onPress={requestDelete}
-                disabled={selectedIds.size === 0}
-              >
-                <Text style={[styles.deleteLabel, selectedIds.size === 0 && styles.deleteLabelDisabled]}>削除</Text>
-              </Pressable>
-            )}
-          </View>
-        </View>
-        <Text style={styles.body}>履歴がありません</Text>
-        <FlatList
-          testID="logs-list"
-          data={[]}
-          renderItem={null as never}
-          refreshing={refreshing}
-          onRefresh={refreshLatest}
-          contentContainerStyle={{ flexGrow: 1 }}
-        />
-      </View>
-    );
-  }
-
   return (
     <View style={containerStyle}>
       <View style={styles.headerRow}>
@@ -231,6 +198,7 @@ export default function LogsScreen({ repo: injectedRepo }: Props) {
         testID="logs-list"
         data={data}
         keyExtractor={(item) => item.id}
+        style={styles.list}
         renderItem={({ item }) => (
           <Pressable
             accessibilityLabel={selectionMode ? `log-select-${item.id}` : `log-item-${item.id}`}
@@ -246,7 +214,12 @@ export default function LogsScreen({ repo: injectedRepo }: Props) {
           </Pressable>
         )}
         ItemSeparatorComponent={() => <View style={styles.separator} />}
-        contentContainerStyle={{ paddingBottom: 24 }}
+        ListEmptyComponent={
+          <View style={styles.emptyState}>
+            <Text style={styles.body}>履歴がありません</Text>
+          </View>
+        }
+        contentContainerStyle={[styles.listContent, data.length === 0 && styles.listEmptyContent]}
         onEndReached={loadMore}
         onEndReachedThreshold={0.4}
         refreshing={refreshing}
@@ -433,6 +406,10 @@ const styles = StyleSheet.create({
   deleteLabel: { fontSize: 14, fontWeight: '700', color: '#dc2626', paddingVertical: 6, paddingHorizontal: 8 },
   deleteLabelDisabled: { color: '#fca5a5' },
   separator: { height: 12 },
+  list: { flex: 1, alignSelf: 'stretch' },
+  listContent: { paddingBottom: 24, flexGrow: 1 },
+  listEmptyContent: { justifyContent: 'center', alignItems: 'center' },
+  emptyState: { alignItems: 'center' },
   card: {
     backgroundColor: '#f5f7fb',
     borderRadius: 12,


### PR DESCRIPTION
## 概要
履歴が空のときに pull-to-refresh が発火しない問題を解消するため、Logs 画面の空状態表示を `FlatList` の `ListEmptyComponent` に統一しました。

## 変更点
- `calmvibe/app/logs.tsx` で空時の早期 return を削除し、`FlatList` を常時描画する構成に変更
- `ListEmptyComponent` を追加して空状態の文言を表示
- `FlatList` に `flex` 系のスタイルを付与し、空状態でも引っ張り領域を確保

## 関連Issue
#18

## 動作確認
- `npm test`
- `npm run lint`
- Android APK で空状態の pull-to-refresh を確認
