### PR TITLE
fix: セッション履歴の保持を安定化

### DIFF
--- a/calmvibe/src/session/__tests__/sqliteRepository.web.test.ts
+++ b/calmvibe/src/session/__tests__/sqliteRepository.web.test.ts
@@ -1,4 +1,8 @@
-import { SqliteSessionRepository } from '../sqliteRepository.web';
+import { SqliteSessionRepository, resetSessionRepositoryStoreForTests } from '../sqliteRepository.web';
+
+beforeEach(() => {
+  resetSessionRepositoryStoreForTests();
+});
 
 describe('SqliteSessionRepository listPage', () => {
   it('limit件を返し、hasNextとnextCursorで続きが判定できる', async () => {


### PR DESCRIPTION

## 概要
- Web の `SessionRepository` が生成インスタンスごとに分断される問題を解消し、同一タブ内で保存した履歴が履歴画面に反映されるようにする。
- Web ではタブ再フォーカス時に最新履歴を再取得して更新できるようにする（Pull-to-Refresh が使えないための補完）。

## 変更点
- `calmvibe/src/session/sqliteRepository.web.ts`
  - メモリストアをモジュールスコープで共有化。
  - テスト用のリセット関数を追加。
- `calmvibe/src/session/__tests__/sqliteRepository.web.test.ts`
  - 共有ストアの影響を排除するため、`beforeEach` でリセット。
- `calmvibe/app/logs.tsx`
  - Web だけ再フォーカス時に `refreshLatest()` を実行。
  - 初回ロードと再取得のロジックを整理。

## 動作確認
- `npm test`
- `npm run lint`

## 影響範囲
- Web のみ（モバイルの挙動は維持）

## 関連 Issue
- #10
