### PR TITLE
履歴画面でWeb削除確認ダイアログを復旧

### DIFF
--- a/calmvibe/app/__tests__/logs-screen.test.tsx
+++ b/calmvibe/app/__tests__/logs-screen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert } from 'react-native';
+import { Alert, Platform } from 'react-native';
 import { act, render, waitFor, fireEvent } from '@testing-library/react-native';
 import LogsScreen from '../logs';
 import { SessionRecord, SessionRepository } from '../../src/session/types';
@@ -64,6 +64,10 @@ const createRepo = (data: SessionRecord[]): SessionRepository => ({
 describe('LogsScreen', () => {
   beforeEach(() => {
     mockIsFocused = true;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('最新順で履歴を表示し、ガイド種別や心拍を含めて表示する', async () => {
@@ -195,7 +199,37 @@ describe('LogsScreen', () => {
     await waitFor(() => {
       expect(alertSpy).toHaveBeenCalledWith('削除に失敗しました', 'もう一度お試しください');
     });
-    alertSpy.mockRestore();
+  });
+
+  it('Webでは確認モーダル経由で選択した履歴を削除する', async () => {
+    jest.replaceProperty(Platform, 'OS', 'web');
+    const deleteMany = jest.fn(async () => undefined);
+    const repo: SessionRepository = {
+      ...createRepo(records),
+      deleteMany,
+    };
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    const { getByLabelText, getByText, getByTestId, queryByLabelText } = render(<LogsScreen repo={repo} />);
+
+    await waitFor(() => {
+      expect(getByText('履歴')).toBeTruthy();
+    });
+
+    fireEvent.press(getByLabelText('logs-select-toggle'));
+    fireEvent.press(getByLabelText('log-select-2'));
+    fireEvent.press(getByLabelText('logs-delete'));
+
+    expect(getByTestId('logs-delete-confirm-modal')).toBeTruthy();
+    expect(alertSpy).not.toHaveBeenCalled();
+
+    fireEvent.press(getByLabelText('logs-delete-confirm'));
+
+    await waitFor(() => {
+      expect(deleteMany).toHaveBeenCalledWith(['2']);
+    });
+    await waitFor(() => {
+      expect(queryByLabelText('log-item-2')).toBeNull();
+    });
   });
 
   it('履歴詳細から編集モーダルを開き、既存値を初期表示する', async () => {

--- a/calmvibe/app/logs.tsx
+++ b/calmvibe/app/logs.tsx
@@ -36,6 +36,7 @@ export default function LogsScreen({ repo: injectedRepo }: Props) {
   const [editDraft, setEditDraft] = useState<RecordDraft | null>(null);
   const [editTargetId, setEditTargetId] = useState<string | null>(null);
   const [editSource, setEditSource] = useState<SessionRecord | null>(null);
+  const [deleteConfirmVisible, setDeleteConfirmVisible] = useState(false);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -153,6 +154,11 @@ export default function LogsScreen({ repo: injectedRepo }: Props) {
 
   const requestDelete = () => {
     if (selectedIds.size === 0) return;
+    // WebではAlert.alertの確認ダイアログに依存せず、画面内モーダルで確実に確認できるようにする。
+    if (isWeb) {
+      setDeleteConfirmVisible(true);
+      return;
+    }
     const count = selectedIds.size;
     Alert.alert('選択した履歴を削除しますか？', `${count}件を削除しますか？`, [
       { text: 'キャンセル', style: 'cancel' },
@@ -272,6 +278,33 @@ export default function LogsScreen({ repo: injectedRepo }: Props) {
               </Pressable>
               <Pressable style={[styles.modalButton, styles.modalClose]} onPress={() => setSelected(null)}>
                 <Text style={styles.modalButtonLabel}>閉じる</Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      )}
+      {deleteConfirmVisible && (
+        <View style={styles.modalBackdrop} testID="logs-delete-confirm-modal">
+          <View style={styles.modalCard}>
+            <Text style={styles.modalTitle}>選択した履歴を削除しますか？</Text>
+            <Text style={styles.meta}>{selectedIds.size}件を削除しますか？</Text>
+            <View style={styles.detailActions}>
+              <Pressable
+                accessibilityLabel="logs-delete-cancel"
+                style={[styles.modalButton, styles.modalClose]}
+                onPress={() => setDeleteConfirmVisible(false)}
+              >
+                <Text style={styles.modalButtonLabel}>キャンセル</Text>
+              </Pressable>
+              <Pressable
+                accessibilityLabel="logs-delete-confirm"
+                style={[styles.modalButton, styles.modalDelete]}
+                onPress={() => {
+                  setDeleteConfirmVisible(false);
+                  void confirmDelete(Array.from(selectedIds));
+                }}
+              >
+                <Text style={styles.modalDeleteLabel}>削除</Text>
               </Pressable>
             </View>
           </View>
@@ -459,7 +492,9 @@ const styles = StyleSheet.create({
   modalButton: { paddingVertical: 10, paddingHorizontal: 14, borderRadius: 10, alignSelf: 'flex-end' },
   modalClose: { backgroundColor: '#e5e7eb' },
   modalEdit: { backgroundColor: '#2563eb' },
+  modalDelete: { backgroundColor: '#dc2626' },
   modalButtonLabel: { color: '#111', fontWeight: '700' },
+  modalDeleteLabel: { color: '#fff', fontWeight: '700' },
   footer: { paddingVertical: 16 },
   detailActions: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8, marginTop: 8 },
 });


### PR DESCRIPTION
## 概要
Web の履歴画面で削除ボタン押下時に確認ダイアログが表示されない不具合を修正しました。Web では画面内モーダルで削除確認を行い、確認後に選択した履歴を一覧から即時に除外します。

## 変更点
- 履歴画面の削除フローに Web 向け確認モーダルを追加
- ネイティブでは既存どおり `Alert.alert` による確認フローを維持
- Web の削除確認モーダル経由で削除できるテストを追加
- 履歴画面テストの後始末を整理し、既存削除系テストを維持

## 関連Issue
- #33

## 動作確認
- `cd calmvibe && npm test -- --runInBand`
  - 17 suite / 75 test passed
- `cd calmvibe && npm run lint`
  - 成功
- `npm run web` で Web を起動し、履歴作成後に「選択」→履歴選択→「削除」で確認モーダルが表示されることを確認
- 確認モーダルで削除確定後、対象履歴が一覧から即時に消えることを確認
